### PR TITLE
support sepcify the type of a xml tag

### DIFF
--- a/JSONObject.java
+++ b/JSONObject.java
@@ -165,6 +165,11 @@ public class JSONObject {
     public static final Object NULL = new Null();
 
     /**
+     * It is a formater to specify the type of tag
+     */
+    private XMLFormater xmlFormater = null;
+
+    /**
      * Construct an empty JSONObject.
      */
     public JSONObject() {
@@ -174,6 +179,14 @@ public class JSONObject {
         // implementations to rearrange their items for a faster element 
         // retrieval based on associative access.
         // Therefore, an implementation mustn't rely on the order of the item.
+        this.map = new HashMap<String, Object>();
+    }
+
+    /**
+     * Construct an empty JSONObject with formater.
+     */
+    public JSONObject(XMLFormater formater) {
+        this.xmlFormater = formater;
         this.map = new HashMap<String, Object>();
     }
 
@@ -478,15 +491,32 @@ public class JSONObject {
         testValidity(value);
         Object object = this.opt(key);
         if (object == null) {
-            this.put(key,
-                    value instanceof JSONArray ? new JSONArray().put(value)
-                            : value);
+            this.put(key, createJSONObject(key, value));
         } else if (object instanceof JSONArray) {
             ((JSONArray) object).put(value);
         } else {
             this.put(key, new JSONArray().put(object).put(value));
         }
         return this;
+    }
+
+    /**
+     * if the tag is specified as {@TAG_TYPE_REPEAT_IN_LIST}, then create a JSONArray to store the value.
+     *
+     * @param key
+     * @param value
+     * @return
+     */
+    private Object createJSONObject(String key, Object value){
+        if(xmlFormater != null && xmlFormater.getRepeatTagNameMap() != null && xmlFormater.getRepeatTagNameMap().containsKey(key)){
+            return new JSONArray().put(value);
+        }
+
+        if(value instanceof JSONArray){
+            return new JSONArray().put(value);
+        }else{
+            return value;
+        }
     }
 
     /**

--- a/XML.java
+++ b/XML.java
@@ -238,10 +238,11 @@ public class XML {
      *            The JSONObject that will include the new material.
      * @param name
      *            The tag name.
+     * @param formater
      * @return true if the close tag is processed.
      * @throws JSONException
      */
-    private static boolean parse(XMLTokener x, JSONObject context, String name, boolean keepStrings)
+    private static boolean parse(XMLTokener x, JSONObject context, String name, XMLFormater formater, boolean keepStrings)
             throws JSONException {
         char c;
         int i;
@@ -326,7 +327,7 @@ public class XML {
         } else {
             tagName = (String) token;
             token = null;
-            jsonobject = new JSONObject();
+            jsonobject = new JSONObject(formater);
             for (;;) {
                 if (token == null) {
                     token = x.nextToken();
@@ -378,7 +379,7 @@ public class XML {
 
                         } else if (token == LT) {
                             // Nested element
-                            if (parse(x, jsonobject, tagName,keepStrings)) {
+                            if (parse(x, jsonobject, tagName, formater, keepStrings)) {
                                 if (jsonobject.length() == 0) {
                                     context.accumulate(tagName, "");
                                 } else if (jsonobject.length() == 1
@@ -488,7 +489,7 @@ public class XML {
      * @throws JSONException Thrown if there is an errors while parsing the string
      */
     public static JSONObject toJSONObject(Reader reader) throws JSONException {
-        return toJSONObject(reader, false);
+        return toJSONObject(reader, null, false);
     }
 
     /**
@@ -506,18 +507,19 @@ public class XML {
      * numbers but will instead be the exact value as seen in the XML document.
      *
      * @param reader The XML source reader.
+     * @param set a XML formater.
      * @param keepStrings If true, then values will not be coerced into boolean
      *  or numeric values and will instead be left as strings
      * @return A JSONObject containing the structured data from the XML string.
      * @throws JSONException Thrown if there is an errors while parsing the string
      */
-    public static JSONObject toJSONObject(Reader reader, boolean keepStrings) throws JSONException {
-        JSONObject jo = new JSONObject();
+    public static JSONObject toJSONObject(Reader reader, XMLFormater formater, boolean keepStrings) throws JSONException {
+        JSONObject jo = new JSONObject(formater);
         XMLTokener x = new XMLTokener(reader);
         while (x.more()) {
             x.skipPast("<");
             if(x.more()) {
-                parse(x, jo, null, keepStrings);
+                parse(x, jo, null, formater, keepStrings);
             }
         }
         return jo;
@@ -545,7 +547,31 @@ public class XML {
      * @throws JSONException Thrown if there is an errors while parsing the string
      */
     public static JSONObject toJSONObject(String string, boolean keepStrings) throws JSONException {
-        return toJSONObject(new StringReader(string), keepStrings);
+        return toJSONObject(new StringReader(string), null, keepStrings);
+    }
+
+    /**
+     * Convert a well-formed (but not necessarily valid) XML string into a
+     * JSONObject. Some information may be lost in this transformation because
+     * JSON is a data format and XML is a document format. XML uses elements,
+     * attributes, and content text, while JSON uses unordered collections of
+     * name/value pairs and arrays of values. JSON does not does not like to
+     * distinguish between elements and attributes. Sequences of similar
+     * elements are represented as JSONArrays. Content text may be placed in a
+     * "content" member. Comments, prologs, DTDs, and <code>&lt;[ [ ]]></code>
+     * are ignored.
+     * 
+     * All values are converted as strings, for 1, 01, 29.0 will not be coerced to
+     * numbers but will instead be the exact value as seen in the XML document.
+     * 
+     * @param string
+     *            The source string.
+     * @param set a XML formater.
+     * @return A JSONObject containing the structured data from the XML string.
+     * @throws JSONException Thrown if there is an errors while parsing the string
+     */
+    public static JSONObject toJSONObject(String string, XMLFormater formater) throws JSONException {
+        return toJSONObject(new StringReader(string), formater, false);
     }
 
     /**

--- a/XMLFormater.java
+++ b/XMLFormater.java
@@ -1,0 +1,51 @@
+package org.json;
+
+/*
+Copyright (c) 2018 JSON.org
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+The Software shall be used for Good, not Evil.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.
+*/
+
+import java.util.HashMap;
+import java.util.Map;
+import java.util.logging.XMLFormatter;
+
+public class XMLFormater {
+
+    /** tag type, repeat element in list */
+    public static final int TAG_TYPE_REPEAT_IN_LIST = 1;
+
+    private Map<String, String> repeatTagNameMap= new HashMap<String, String>();
+
+
+    public void setTagType(String tagName, int type){
+        switch (type) {
+            case TAG_TYPE_REPEAT_IN_LIST:
+                repeatTagNameMap.put(tagName, tagName);
+                break;
+        }
+    }
+
+    public Map<String, String> getRepeatTagNameMap() {
+        return repeatTagNameMap;
+    }
+
+}


### PR DESCRIPTION
Solve the question：
When converting xml to json, if a list has multiple child elements in the xml, it will be converted into a JSONArray. If there is only one child element, it will not be converted into a JSONArray.
In this modification, the type of an xml tag specified before conversion is the duplicate tag in the list. Even if the list has only one child element in the conversion process, it will be replaced with a JSONArray.
